### PR TITLE
updated let & letp to return name of the method

### DIFF
--- a/lib/rlet/let.rb
+++ b/lib/rlet/let.rb
@@ -10,11 +10,15 @@ module Let
           __memoized[name] = instance_eval(&block)
         end
       end
+
+      name
     end
 
     def letp(name, &block)
       let(name, &block)
       protected(name)
+
+      name
     end
   end
 

--- a/lib/rlet/version.rb
+++ b/lib/rlet/version.rb
@@ -1,3 +1,3 @@
 module RLet
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
updated let & letp to return name of the method.

This allows the user to do stuff like

private let(:view) { "fox" }  # Using private/protected this way, came with Ruby 2.1+
or even

helper_method letp(:view) { "fox" } 

-daniel

A lot of the "spaces" that are removed from the file, are just "empty line spaces"...
